### PR TITLE
Move template server off the Gradle plugin temporarily

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,22 +1,22 @@
 plugins {
     id 'java'
-    id 'com.minestom.gradle' version '1.0'
     id "com.github.johnrengelman.shadow" version "6.1.0"
 }
 
 group 'com.example'
 version '1.0'
 
-minestom {
-    version = '-SNAPSHOT'
-}
-
 repositories {
     mavenCentral()
+
+    maven { url 'https://repo.spongepowered.org/maven' }
+    maven { url 'https://repo.velocitypowered.com/snapshots/' }
+    maven { url 'https://libraries.minecraft.net' }
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
-
+    implementation 'com.github.Minestom:Minestom:25176e9b9d'
 }
 
 jar {


### PR DESCRIPTION
Intellij seems to forget about the dependencies added by the Gradle plugin when you reload the project and doesn't auto reload the Gradle project which means you need to do it manually every time which is rather annoying.

I'm leaving the gradle plugin in demo server for now and I will switch the template back once fixed.